### PR TITLE
refactor: change filtering to account for .ts and .js

### DIFF
--- a/src/handlers/commandHandler.ts
+++ b/src/handlers/commandHandler.ts
@@ -6,7 +6,7 @@ const commands = new Map<string, Command>();
 
 const commandFiles = fs
   .readdirSync(path.join(__dirname, '../commands'))
-  .filter((file) => file.endsWith('.ts') && file !== 'index.ts');
+  .filter((file) => (file.endsWith('.ts') || file.endsWith('.js')) && file !== 'index.ts');
 
 for (const file of commandFiles) {
   const commandModule = require(path.join(__dirname, '../commands', file));


### PR DESCRIPTION
Fix for Linux when serving up transpiled js. Keeping filtering to look for both to cover both .ts and .js for development reasons as well as if running from Windows or Linux.