### PR TITLE
update: more robust regex pattern matching

### DIFF
--- a/src/events/onMessageCreate.ts
+++ b/src/events/onMessageCreate.ts
@@ -3,28 +3,41 @@ import { Message } from 'discord.js';
 const ignoredRoles = [
   '814181424840179733', // Admin
   '819891382114189332', // Shrimp Supreme
-  '933681479878324234', // Dictator
   '892853647950618675', // Overextended
   '831961060314972170', // Senior Moderator
   '945991885783175189', // Moderator
-  '906292806098759750', // Contributor
-  '1120932120056057926', // Affiliate
-  '816709868764921876', // Coffee Drinker
-  '842456416019021895', // Recognized Member
   '1140367518230397029', // GitHub
 ];
 const patterns = [
-  /why\s+can'?t\s+i\s+(not\s+)?(type|post)\s+in\s+support\??/i,
-  /how\s+can\s+i\s+get\s+verified\s+(to\s+)?(type|post)\s+in\s+support/i,
-  /can'?t\s+(type|post)\s+in\s+support/i,
-  /help\s+(with\s+)?(typing|posting)\s+in\s+support/i,
-  /help/i,
-  /cant\s+type/i,
-  /can'?t\s+type/i,
-  /need\s+support/i,
-  /support\s+needed/i,
-  /how\s+can\s+i/i,
-  /\bsupport\b/i,
+  /(\bwhy\s+can'?t\s+i\s+(not\s+)?(type|post)\s+in\s+support\??\b)|(\bwhy\s+can'?t\s+i\b)|(\btype|post\b)|(\bsupport\b)/i,
+  /(\bhow\s+can\s+i\s+get\s+verified\s+(to\s+)?(type|post)\s+in\s+support\b)|(\bhow\s+can\s+i\b)|(\bget\s+verified\b)|(\btype|post\b)|(\bsupport\b)/i,
+  /(\bcan'?t\s+(type|post)\s+in\s+support\b)|(\bcan'?t\b)|(\btype|post\b)|(\bsupport\b)/i,
+  /(\bhelp\s+(with\s+)?(typing|posting)\s+in\s+support\b)|(\bhelp\b)|(\btyping|posting\b)|(\bsupport\b)/i,
+  /(\bhelp\b)/i,
+  /(\bcan'?t\s+(type|post)\b)|(\bcan'?t\b)|(\btype|post\b)/i,
+  /(\bcant\s+(type|post)\b)|(\bcant\b)|(\btype|post\b)/i,
+  /(\bneed\s+support\b)|(\bneed\b)|(\bsupport\b)/i,
+  /(\bsupport\s+needed\b)|(\bsupport\b)|(\bneeded\b)/i,
+  /(\bhow\s+can\s+i\b)|(\bhow\b)|(\bcan\b)|(\bi\b)/i,
+  /(\bsupport\b)/i,
+  /(\bcan'?t\s+post\b)|(\bcan'?t\b)|(\bpost\b)/i,
+  /(\bunable\s+to\s+post\b)|(\bunable\b)|(\bto\b)|(\bpost\b)/i,
+  /(\bnot\s+allowed\s+to\s+post\b)|(\bnot\b)|(\ballowed\b)|(\bto\b)|(\bpost\b)/i,
+  /(\bposting\s+issue\b)|(\bposting\b)|(\bissue\b)/i,
+  /(\btrouble\s+(with\s+)?(typing|posting)\s+in\s+support\b)|(\btrouble\b)|(\bwith\b)|(\btyping|posting\b)|(\bsupport\b)/i,
+  /(\block(ed)?\s+(from\s+)?(typing|posting)\s+in\s+support\b)|(\block(ed)?\b)|(\bfrom\b)|(\btyping|posting\b)|(\bsupport\b)/i,
+  /(\baccess\s+issue\s+(with\s+)?support\b)|(\baccess\b)|(\bissue\b)|(\bwith\b)|(\bsupport\b)/i,
+  /(\bpermission\s+to\s+(type|post)\s+in\s+support\b)|(\bpermission\b)|(\bto\b)|(\btype|post\b)|(\bsupport\b)/i,
+  /(\bhow\s+to\s+(type|post)\s+in\s+support\b)|(\bhow\b)|(\bto\b)|(\btype|post\b)|(\bsupport\b)/i,
+  /(\bverify\b)/i,
+  /(\bissue\s+(with\s+)?(typing|posting)\s+in\b)|(\bissue\b)|(\bwith\b)|(\btyping|posting\b)|(\bin\b)/i,
+  /(\bcan'?t\s+access\s+support\b)|(\bcan'?t\b)|(\baccess\b)|(\bsupport\b)/i,
+  /(\bno\s+access\s+to\s+support\b)|(\bno\b)|(\baccess\b)|(\bto\b)|(\bsupport\b)/i,
+  /(\bwhy\s+am\s+i\s+(not\s+)?allowed\s+to\s+(type|post)\b)|(\bwhy\b)|(\bam\b)|(\bi\b)|(\bnot\b)|(\ballowed\b)|(\bto\b)|(\btype|post\b)/i,
+  /(\bhlep\b)/i, 
+  /(\bsuport\b)/i, 
+  /(\bhalp\b)/i, 
+  /(\bsupport\b)/i, 
 ];
 
 const guidelines = '<#1114827068337815612>';
@@ -36,11 +49,6 @@ interface ChannelResponses {
 const generalResponseMessages = [`For Support Read: ${guidelines}`];
 
 const channelSpecificResponses: ChannelResponses = {
-  // Scripting Channel
-  '869564691637231676': [
-    `This channel is for general scripting, ${guidelines}.`,
-    `There is a support channel, maybe you should read ${guidelines}.`,
-  ],
   // General Channel
   '813030955598086177': [
     `Read the channel description, dip shit.`,


### PR DESCRIPTION
We now will catch things no matter where they are in the message that matches our regex patterns.
Trimmed down the roles we are ignoring as they overlap.
Removed scripting channel responses as it didn't make sense to have with how we get for GitHub role.